### PR TITLE
Remove localhost bind by default

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -22,7 +22,7 @@ func NewServer() *http.Server {
 
 	// Declare Server config
 	server := &http.Server{
-		Addr:         fmt.Sprintf(":%d", NewServer.port),
+		Addr:         fmt.Sprintf("0.0.0.0:%d", NewServer.port),
 		Handler:      NewServer.RegisterRoutes(),
 		IdleTimeout:  time.Minute,
 		ReadTimeout:  10 * time.Second,


### PR DESCRIPTION
This pr adds a specific bind to 0.0.0.0 since binding to localhost makes the application not listen to anything from outside it's local network.