### PR TITLE
Updating go test build step name

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -6,9 +6,8 @@ on:
   pull_request:
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: golangci/golangci-lint-action@4
+    - uses: golangci/golangci-lint-action@v4
       with:
           version: v1.54
 

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -6,6 +6,14 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: golangci/golangci-lint-action@4
+      with:
+          version: v1.54
+
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This pr updates the build step for the go-test workflow file. It also adds golangci-lint to run before the test step.